### PR TITLE
fixed README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The data updated at least once per a day.
 
 ### Transformations
 
-All applied transformation sets are documented in the `Jupyter` notebook: https://github.com/starschema/COVID-19-data/blob/master/JH_COVID-19.ipynb
+All applied transformation sets are documented in the `Jupyter` notebook: https://github.com/starschema/COVID-19-data/blob/master/notebooks/JHU_COVID-19.ipynb
 
 ## Credits
 


### PR DESCRIPTION
for the Jupyter notebook with Python transformations
(lead to 404 before)