### PR TITLE
Normalise RotC and Taiwan

### DIFF
--- a/notebooks/JHU_COVID-19.ipynb
+++ b/notebooks/JHU_COVID-19.ipynb
@@ -208,6 +208,8 @@
     "    \"Taipei and environs\": \"Taiwan\",\n",
     "    \"Viet Nam\": \"Vietnam\",\n",
     "    \"occupied Palestinian territory\": \"Palestine\",\n",
+    "    \"Taiwan*\": \"Taiwan\",\n",
+    "    \"Congo (Brazzaville)\": \"Republic of the Congo\"\n",
     "}\n",
     "\n",
     "\n",


### PR DESCRIPTION
Normalized the name of Congo (Brazzaville) to Republic of the Congo and removed asterisk from Taiwan.