### PR TITLE
Added entry to renaming dict to handle Gambia alt names

### DIFF
--- a/notebooks/JHU_COVID-19.ipynb
+++ b/notebooks/JHU_COVID-19.ipynb
@@ -160,6 +160,7 @@
     "    \"Congo (Brazzaville)\": \"Congo\",\n",
     "    \"Congo (Kinshasa)\": \"Congo, The Democratic Republic of the\",\n",
     "    \"Gambia, The\": \"Gambia\",\n",
+    "    \"The Gambia\": \"Gambia\",\n",
     "    \"Tanzania\": \"Tanzania, United Republic of\",\n",
     "    \"US\": \"United States\",\n",
     "    \"Curacao\": \"Curaçao\",\n",
@@ -468,7 +469,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.6"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Gambia is styled as 'Gambia', 'The Gambia', and 'Gambia, The'. There was an entry missing in the renaming dictionary.