### PR TITLE
Fix nyc health

### DIFF
--- a/notebooks/JHU_COVID-19.ipynb
+++ b/notebooks/JHU_COVID-19.ipynb
@@ -135,7 +135,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['FIPS'] = df['FIPS'].apply(lambda row: row.zfill(5) if not row == '' else row)"
+    "df['FIPS'].loc[df['FIPS'] != ''] = df['FIPS'].str.zfill(5)"
    ]
   },
   {
@@ -151,7 +151,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['FIPS'] = df['FIPS'].apply(lambda row: re.sub(r'^(0{3,})(\\d{2})$', r'\\g<2>\\g<1>', row))"
+    "df['FIPS'] = df['FIPS'].replace(r'^(0{3,})(\\d{2})$', r'\\g<2>\\g<1>', regex=True)"
    ]
   },
   {
@@ -163,6 +163,15 @@
     "df = df.astype({\n",
     "    'FIPS': 'object'\n",
     "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['Admin2'] = df['Admin2'].replace(r'(?i)unassigned', 'unassigned', regex=True) "
    ]
   },
   {
@@ -554,6 +563,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cldf_us['FIPS'].loc[cldf_us['County'] == 'unassigned'] = numpy.nan\n",
+    "cldf_us['Lat'].loc[cldf_us['County'] == 'unassigned'] = numpy.nan\n",
+    "cldf_us['Long'].loc[cldf_us['County'] == 'unassigned'] = numpy.nan"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -595,7 +615,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = cldf_nonus.append(cldf_us)"
+    "result = cldf_nonus.append(cldf_us)\n",
+    "result['County'] = result['County'].replace('', numpy.nan)\n",
+    "result['FIPS'] = result['FIPS'].replace('', numpy.nan)\n",
+    "result['Lat'] = result['Lat'].replace(r'^0?$', numpy.nan, regex=True)\n",
+    "result['Lat'] = result['Lat'].replace(0, numpy.nan)\n",
+    "result['Long'] = result['Long'].replace(r'^0?$', numpy.nan, regex=True)\n",
+    "result['Long'] = result['Long'].replace(0, numpy.nan)\n",
+    "result['Province/State'] = result['Province/State'].replace('', numpy.nan)"
    ]
   },
   {

--- a/notebooks/NYC_HEALTH_TESTS.ipynb
+++ b/notebooks/NYC_HEALTH_TESTS.ipynb
@@ -21,7 +21,8 @@
     "import json\n",
     "import re\n",
     "import csv\n",
-    "from datetime import datetime"
+    "from datetime import datetime\n",
+    "import pycountry"
    ]
   },
   {
@@ -78,8 +79,7 @@
    "outputs": [],
    "source": [
     "response = session.get(f'{API_ENDPOINT}/{REPO_OWNER}/{REPO_NAME}/commits')\n",
-    "print(f'{API_ENDPOINT}/{REPO_OWNER}/{REPO_NAME}/commits')\n",
-    "response.text"
+    "print(f'{API_ENDPOINT}/{REPO_OWNER}/{REPO_NAME}/commits')"
    ]
   },
   {
@@ -128,6 +128,38 @@
     "df['Date'] = pd.to_datetime(df['Date'], format=\"%Y-%m-%dT%H:%M:%SZ\")  # parse date\n",
     "df = df.replace('NA', np.nan)  # parse NA\n",
     "df = df.replace('nan', np.nan)  # parse NA"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zcta_to_fips = pd.read_csv('https://www2.census.gov/geo/docs/maps-data/data/rel/zcta_county_rel_10.txt').set_index('ZCTA5')\n",
+    "zcta_to_fips = zcta_to_fips.astype({\n",
+    "    'STATE': 'object',\n",
+    "    'COUNTY': 'object'\n",
+    "})\n",
+    "\n",
+    "fips_to_state = pd.read_csv('https://raw.githubusercontent.com/kjhealy/fips-codes/master/county_fips_master.csv', encoding =\"ISO-8859-1\").set_index('fips')\n",
+    "\n",
+    "def map_zcta_to_fips(zcta_code):\n",
+    "    try:\n",
+    "        return zcta_to_fips.loc[int(zcta_code), 'GEOID'] \n",
+    "    except (ValueError, KeyError, TypeError):\n",
+    "        return\n",
+    "    \n",
+    "def map_fips_to_state(fips):\n",
+    "    try:\n",
+    "        return fips_to_state.loc[int(fips), 'state_abbr']\n",
+    "    except (ValueError, KeyError, TypeError):\n",
+    "        return\n",
+    "    \n",
+    "df['FIPS'] = df['MODZCTA'].apply(lambda row: map_zcta_to_fips(row))\n",
+    "df['Country/Region'] = \"United States\"\n",
+    "df['ISO3166-1'] = \"US\"\n",
+    "df['ISO3166-2'] = df['FIPS'].apply(lambda row: map_fips_to_state(row))"
    ]
   },
   {

--- a/notebooks/NYC_HEALTH_TESTS.ipynb
+++ b/notebooks/NYC_HEALTH_TESTS.ipynb
@@ -161,8 +161,7 @@
    "outputs": [],
    "source": [
     "df['zcta_cum.perc_pos'] = df['zcta_cum.perc_pos'].replace('NA', np.nan)\n",
-    "df['MODZCTA'] = df['MODZCTA'].replace('99999', np.nan)\n",
-    "df = df.replace('', np.nan)"
+    "df['MODZCTA'] = df['MODZCTA'].replace('99999', '')"
    ]
   },
   {
@@ -216,15 +215,6 @@
    "outputs": [],
    "source": [
     "df.to_csv(output_folder + \"NYC_HEALTH_TESTS.csv\", index=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.dtypes"
    ]
   }
  ],

--- a/notebooks/NYC_HEALTH_TESTS.ipynb
+++ b/notebooks/NYC_HEALTH_TESTS.ipynb
@@ -126,8 +126,7 @@
    "outputs": [],
    "source": [
     "df['Date'] = pd.to_datetime(df['Date'], format=\"%Y-%m-%dT%H:%M:%SZ\")  # parse date\n",
-    "df = df.replace('NA', np.nan)  # parse NA\n",
-    "df = df.replace('nan', np.nan)  # parse NA"
+    "df['MODZCTA'] = df['MODZCTA'].replace(['NA'], '99999')  # parse NA"
    ]
   },
   {
@@ -137,29 +136,33 @@
    "outputs": [],
    "source": [
     "zcta_to_fips = pd.read_csv('https://www2.census.gov/geo/docs/maps-data/data/rel/zcta_county_rel_10.txt').set_index('ZCTA5')\n",
-    "zcta_to_fips = zcta_to_fips.astype({\n",
-    "    'STATE': 'object',\n",
-    "    'COUNTY': 'object'\n",
-    "})\n",
-    "\n",
-    "fips_to_state = pd.read_csv('https://raw.githubusercontent.com/kjhealy/fips-codes/master/county_fips_master.csv', encoding =\"ISO-8859-1\").set_index('fips')\n",
-    "\n",
-    "def map_zcta_to_fips(zcta_code):\n",
-    "    try:\n",
-    "        return zcta_to_fips.loc[int(zcta_code), 'GEOID'] \n",
-    "    except (ValueError, KeyError, TypeError):\n",
-    "        return\n",
-    "    \n",
-    "def map_fips_to_state(fips):\n",
-    "    try:\n",
-    "        return fips_to_state.loc[int(fips), 'state_abbr']\n",
-    "    except (ValueError, KeyError, TypeError):\n",
-    "        return\n",
-    "    \n",
-    "df['FIPS'] = df['MODZCTA'].apply(lambda row: map_zcta_to_fips(row))\n",
+    "zcta_to_fips = zcta_to_fips[~zcta_to_fips.index.duplicated(keep='first')]\n",
+    "df['FIPS'] = ''\n",
+    "df['FIPS'].loc[df['MODZCTA'] != '99999'] = zcta_to_fips.loc[list(map(lambda x: int(x), df['MODZCTA'].loc[df['MODZCTA'] != '99999'].tolist())), 'GEOID'].tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "df['Country/Region'] = \"United States\"\n",
     "df['ISO3166-1'] = \"US\"\n",
-    "df['ISO3166-2'] = df['FIPS'].apply(lambda row: map_fips_to_state(row))"
+    "fips_to_state = pd.read_csv('https://raw.githubusercontent.com/kjhealy/fips-codes/master/county_fips_master.csv', encoding =\"ISO-8859-1\").set_index('fips')\n",
+    "df['ISO3166-2'] = ''\n",
+    "df['ISO3166-2'].loc[df['FIPS'] != ''] = fips_to_state.loc[df['FIPS'].loc[df['FIPS'] != ''].tolist()]['state_abbr'].tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['zcta_cum.perc_pos'] = df['zcta_cum.perc_pos'].replace('NA', np.nan)\n",
+    "df['MODZCTA'] = df['MODZCTA'].replace('99999', np.nan)\n",
+    "df = df.replace('', np.nan)"
    ]
   },
   {
@@ -171,7 +174,8 @@
     "df = df.astype({\n",
     "    'Positive': 'int32',\n",
     "    'Total': 'int32',\n",
-    "    'zcta_cum.perc_pos': 'float32'\n",
+    "    'zcta_cum.perc_pos': 'float32',\n",
+    "    'FIPS': 'object'\n",
     "})"
    ]
   },

--- a/notebooks/NYC_HEALTH_TESTS.ipynb
+++ b/notebooks/NYC_HEALTH_TESTS.ipynb
@@ -147,11 +147,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['Country/Region'] = \"United States\"\n",
-    "df['ISO3166-1'] = \"US\"\n",
+    "df['Country_Region'] = \"United States\"\n",
+    "df['ISO3166_1'] = \"US\"\n",
     "fips_to_state = pd.read_csv('https://raw.githubusercontent.com/kjhealy/fips-codes/master/county_fips_master.csv', encoding =\"ISO-8859-1\").set_index('fips')\n",
-    "df['ISO3166-2'] = ''\n",
-    "df['ISO3166-2'].loc[df['FIPS'] != ''] = fips_to_state.loc[df['FIPS'].loc[df['FIPS'] != ''].tolist()]['state_abbr'].tolist()"
+    "df['ISO3166_2'] = ''\n",
+    "df['ISO3166_2'].loc[df['FIPS'] != ''] = fips_to_state.loc[df['FIPS'].loc[df['FIPS'] != ''].tolist()]['state_abbr'].tolist()"
    ]
   },
   {
@@ -185,6 +185,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "df = df.rename(columns={\n",
+    "    \"zcta_cum.perc_pos\": \"ZTCA_CUM_PERC_POS\"\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "df[\"Last_Updated_Date\"] = datetime.utcnow()\n",
     "df['Last_Reported_Date'] = df['Date'] == df['Date'].max()"
    ]
@@ -205,6 +216,15 @@
    "outputs": [],
    "source": [
     "df.to_csv(output_folder + \"NYC_HEALTH_TESTS.csv\", index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.dtypes"
    ]
   }
  ],


### PR DESCRIPTION
NYC_HEALTH_TEST
- added ISO3166_1, ISO3166_2, Country/Region and FIPS columns
- fixed notebook bad performance - replaced .apply
- fixed NULL values

JHU_COVID_19
- fixed Unassigned and unassigned values
- cleansed data entry fields containing unassigned fields to have NULL as unavailable values (such as longitude and latitude 0 -> NULL, FIPS 990+ State ID -> NULL)
