### PR TITLE
Enh/history

### DIFF
--- a/dags/covid_etl_dag.py
+++ b/dags/covid_etl_dag.py
@@ -65,6 +65,9 @@ def create_etl_dag(dag_id, args):
     # the QA sql file to perform checks , for example: /home/ec2-user/COVID-19-data/snowflake/sql/JHU_COVID-19_HIST.sql
     sql_file_glob = SQL_FOLDER + basename + "*.sql"
 
+    # update template_params with "TableName" item. Using the {{ TableName }} parameter in the sql files will reference the name of the actual table.
+    template_params.update({"TableName": basename})
+
     dag = DAG(
         dag_id=dag_id,
         default_args=args,


### PR DESCRIPTION
Execution flow rewrite (`dags/covid_etl_dag.py`):
Added` all_*.sql` files to trigger SQL file execution under the `snowflake/sql`.

With the rewrite, the execution steps are modified by running SQL scripts located in the `snowflake/sql` directory (by creating separate tasks for each script and executing them in parallel). Now each SQL file matching the name `snowflake/sql/<table name>*.sql` name run after the table load along with all the files matching the name `snowflake/sql/all_*.sql`. Note, that every `all_*.sql` script runs after every table load.

Added the SQL script parameter `TableName` to the executor task. Using the `{{ TableName }} `parameter in the scripts referencing the actual table.
 

