### PR TITLE
Change schedule for NYT Reopen to daily

### DIFF
--- a/refresh_schedules.json
+++ b/refresh_schedules.json
@@ -12,7 +12,7 @@
     "GOOG_GLOBAL_MOBILITY_REPORT": "@daily",
     "ECDC_GLOBAL": "@daily",
     "JHU_DASHBOARD_COVID_19_GLOBAL": "@hourly",
-    "NYT_US_REOPEN_STATUS": "@hourly"
+    "NYT_US_REOPEN_STATUS": "@daily"
   },
   "github": {
     "JHU_COVID_19_TIMESERIES": "https://api.github.com/repos/CSSEGISandData/COVID-19/commits?since={}&path=csse_covid_19_data/csse_covid_19_time_series",


### PR DESCRIPTION
Changed schedule from hourly to daily.