### PR TITLE
to_csv consistency issue fix

### DIFF
--- a/notebooks/ECDC_GLOBAL.ipynb
+++ b/notebooks/ECDC_GLOBAL.ipynb
@@ -174,26 +174,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "df.sample(5)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.dtypes"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -214,7 +194,7 @@
     "    \"deaths\",\n",
     "    \"CASES_SINCE_PREV_DAY\",\n",
     "    \"DEATHS_SINCE_PREV_DAY\",\n",
-    "    \"POPULATION\",\n",
+    "    \"popData2019\",\n",
     "    \"DATE\",\n",
     "    \"LAST_UPDATE_DATE\",\n",
     "    \"LAST_REPORTED_FLAG\"\n",

--- a/notebooks/PCM_DPS_COVID19.ipynb
+++ b/notebooks/PCM_DPS_COVID19.ipynb
@@ -86,15 +86,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data.columns"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "data.columns = [\n",
     "    'Date', 'State', 'Region_Code', 'Region', 'Lat', 'Long', 'Hospitalized',\n",
     "    'Intensive_Care', 'Total_Hospitalized', 'Home_Isolation', 'Total_Positive',\n",
@@ -197,15 +188,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data.to_csv(output_folder + OUTPUT_FILE_FULL, index=False, \n",
-    "            header=True,\n",
-    "            columns=[\"Country/Region\", \"Province/State\", \"Date\", \"Hospitalized\", \"Intensive_Care\", \"Total_Hospitalized\",  'Home_Isolation', 'Total_Positive', 'New_Positive', 'Discharged_Healed', 'Deceased', 'Total_Cases', 'Tested', \n",
-    "                  'Hospitalized_Since_Prev_Day', 'Intensive_Care_Since_Prev_Day',\n",
-    "                  'Total_Hospitalized_Since_Prev_Day', 'Home_Isolation_Since_Prev_Day',\n",
-    "                  'Total_Positive_Since_Prev_Day', 'Discharged_Healed_Since_Prev_Day',\n",
-    "                  'Deceased_Since_Prev_Day', 'Total_Cases_Since_Prev_Day',\n",
-    "                  'Tested_Since_Prev_Day', \"ISO3166_1\", \"ISO3166_2\", \"Note_IT\", \"Note_EN\",\n",
-    "                  'Last_Update_Date','Last_Reported_Flag'])"
+    "data[\"Note_EN\"] = \"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data.to_csv(\n",
+    "    output_folder + OUTPUT_FILE_FULL,\n",
+    "    index=False,\n",
+    "    header=True,\n",
+    "    columns=[\n",
+    "        \"Country/Region\", \"Province/State\", \"Date\", \"Hospitalized\",\n",
+    "        \"Intensive_Care\", \"Total_Hospitalized\", 'Home_Isolation',\n",
+    "        'Total_Positive', 'New_Positive', 'Discharged_Healed', 'Deceased',\n",
+    "        'Total_Cases', 'Tested', 'Hospitalized_Since_Prev_Day',\n",
+    "        'Intensive_Care_Since_Prev_Day', 'Total_Hospitalized_Since_Prev_Day',\n",
+    "        'Home_Isolation_Since_Prev_Day', 'Total_Positive_Since_Prev_Day',\n",
+    "        'Discharged_Healed_Since_Prev_Day', 'Deceased_Since_Prev_Day',\n",
+    "        'Total_Cases_Since_Prev_Day', 'Tested_Since_Prev_Day', \"ISO3166_1\",\n",
+    "        \"ISO3166_2\", \"Note_IT\", \"Note_EN\", 'Last_Update_Date',\n",
+    "        'Last_Reported_Flag'\n",
+    "    ])"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas==0.20.3
+pandas
 requests
 pygsheets
 tqdm


### PR DESCRIPTION
This is an error related to this issue: https://github.com/pandas-dev/pandas/issues/26613 – where a `to_csv` call lists columns that do not match existing `pd.DataFrame` column names, `pandas` yields a pretty confusing error referring to `.loc` indexing rather than what's actually wrong. This PR incrementally fixes this.

(DO NOT MERGE YET)