### PR TITLE
Add LOG_TYPE column to the HDX_ACAPS table

### DIFF
--- a/notebooks/HDX_ACAPS.ipynb
+++ b/notebooks/HDX_ACAPS.ipynb
@@ -129,7 +129,7 @@
    "source": [
     "df.to_csv(path_or_buf=output_folder + \"HDX_ACAPS.csv\", quoting = csv.QUOTE_NONNUMERIC,\n",
     "          columns=[\n",
-    "              \"COUNTRY_STATE\", \"ADMIN_2\", \"REGION\", \"CATEGORY\", \"MEASURE\",\n",
+    "              \"COUNTRY_STATE\", \"ADMIN_2\", \"REGION\", \"LOG_TYPE\", \"CATEGORY\", \"MEASURE\",\n",
     "              \"TARGETED_POP_GROUP\", \"COMMENTS\", \"NON_COMPLIANCE\",\n",
     "              \"DATE_IMPLEMENTED\", \"SOURCE\", \"SOURCE_TYPE\", \"LINK\",\n",
     "              \"ENTRY_DATE\", \"ISO3166_1\", \"LAST_UPDATED_DATE\"\n",
@@ -140,8 +140,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3"
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -153,7 +154,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.0-final"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/HDX_ACAPS.ipynb
+++ b/notebooks/HDX_ACAPS.ipynb
@@ -63,15 +63,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "f\"https://data.humdata.org{data}\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "def get_country(row):\n",
     "    country = pycountry.countries.get(alpha_3=row.ISO)\n",
     "    \n",
@@ -97,15 +88,6 @@
    "outputs": [],
    "source": [
     "df = df[df.sum(axis=1) > 0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df = df.drop(columns=[\"ISO\", \"Alternative source\"], axis=1)"
    ]
   },
   {
@@ -158,9 +140,8 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
+   "name": "python3",
+   "display_name": "Python 3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -172,7 +153,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.9.0-final"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This is a pull request to address Issue #298 opened by me.

While I was there I also removed two cells of the notebook which don't do anything during the loads (one printed a string, the other removed columns that would have renamed two cells later).

I tested the modification on my local machine and got a well-formed csv as a result. Not sure if anything else is needed to extend the receiving table in Snowflake.